### PR TITLE
Add onboarding documentation

### DIFF
--- a/docs/echolab_onboarding.md
+++ b/docs/echolab_onboarding.md
@@ -1,0 +1,63 @@
+# New ECHOLab Member Onboarding Checklist
+
+## Accounts and Access
+
+- [ ] **ECHOLab GitHub organization**
+    - Create a GitHub account if you do not already have one.
+    - Provide your GitHub username to Sam.
+    - Sam will add you to the ECHOLab GitHub organization.
+    - GitHub organization: https://github.com/echolab-stanford
+
+- [ ] **Lab shared calendar**
+    - Provide the Google account you would like to use for the ECHOLab shared calendar.
+    - Sam will add you to the calendar.
+
+- [ ] **Stanford FSE Slack workspace**
+    - Provide your Stanford email address.
+    - Sam will add you to the Slack workspace.
+
+- [ ] **Lab Dropbox account**
+    - Dropbox being phased out of lab activities but still useful for some applications.
+    - To be added, provide the email address associated with your Dropbox account.
+    - Sam will add you to the shared Dropbox workspace.
+
+- [ ] **Sherlock and Oak access**
+    - Oak: Provide your Stanford email address. Sam will add you to Oak/mburke to get access to the lab's shared data.
+- [ ] **Sherlock and Oak access**
+    - **Oak:** Provide your Stanford email address. Sam will add you to Oak/mburke to get access to the lab's shared data.
+    - **Sherlock:** Request access through Stanford Research Computing. Sam or other lab members can help direct you to the appropriate contacts.
+    - You will send an email requesting access and CC Marshall.
+    - Stanford Research Computing will request Marshall's approval.
+    - Marshall will approve the request and your account will be created.
+
+## Lab Directory
+
+- [ ] **Lab website profile**
+    - Send a headshot to Marshall.
+    - Provide any additional information needed for your profile page.
+
+---
+
+## ECHOLab Shared Calendar
+
+Most lab members use a personal Google account for the ECHOLab shared calendar. This is generally the simplest option because all lab members have permission to edit the calendar, create events, and update meeting details.
+
+To gain access, provide Sam with the Google account you would like to use for the calendar.
+
+### Outlook / Stanford Calendar Integration
+
+Some lab members primarily use their Stanford Outlook calendar to manage meetings and availability. In this case, you can subscribe to the ECHOLab Google Calendar so that ECHOLab events appear alongside your Stanford calendar events.
+
+**Notes:**
+- The Outlook version of the calendar is read-only.
+- Calendar updates are not immediate and may take several hours to appear.
+- If you need to create or edit ECHOLab events, you should continue to use the Google Calendar directly.
+
+**Setup instructions:**
+
+1. Obtain the ECHOLab calendar subscription URL from Sam.
+2. In Outlook Calendar, click **Add Calendar**.
+3. Select **Subscribe from Web**.
+4. Paste the calendar subscription URL.
+5. Choose a name and folder location for the calendar.
+6. Save the subscription.

--- a/docs/employee_onboarding.md
+++ b/docs/employee_onboarding.md
@@ -1,0 +1,19 @@
+new_employee_onboarding.md
+
+# New Employee Onboarding Checklist
+
+
+
+## Campus and Office Setup
+
+- [ ] **Stanford ID card**
+    - Obtain a Stanford ID card during orientation or through the Stanford ID Card Office.
+
+- [ ] **Building access**
+    - Activate your Stanford ID card for after-hours access to the building.
+    - The building manager can assist with access requests.
+
+- [ ] **Office key**
+    - Obtain a key for your shared office (Y2E2 362).
+    - Sonal can assist with this process.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,9 @@ nav:
     - 'palife.md'
     - 'resources.md'
     - 'expectations.md'
+    - 'ECHOLab Onboarding': 'echolab_onboarding.md'
+    - 'Employee Onboarding': 'new_employee_onboarding.md'
+    
   - Graduate students:
     - 'recs.md'
     - 'life.md'


### PR DESCRIPTION
created two separate onboard docs one for existing stanford people joining lab (mostly students) one for new hires coming from outside standford (mostly predocs/postdocs/research staff)